### PR TITLE
unique name for each plugin instance

### DIFF
--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -46,8 +46,8 @@ impl<S: StateData> Plugin for ProgressPlugin<S> {
         }
     }
 
-    fn is_unique(&self) -> bool {
-        false
+    fn name(&self) -> &str {
+        &self.plugin_name
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,12 +193,15 @@ pub struct ProgressPlugin<S: StateData> {
     pub next_state: Option<S>,
     /// Whether to enable the optional assets tracking feature
     pub track_assets: bool,
+    // Unique name, made using the loading state
+    pub(crate) plugin_name: String,
 }
 
 impl<S: StateData> ProgressPlugin<S> {
     /// Create a [`ProgressPlugin`] running during the given State
     pub fn new(state: S) -> Self {
         ProgressPlugin {
+            plugin_name: format!("{}({:?})", std::any::type_name::<Self>(), state),
             state,
             next_state: None,
             track_assets: false,

--- a/src/loopless.rs
+++ b/src/loopless.rs
@@ -67,8 +67,8 @@ impl<S: StateData> Plugin for ProgressPlugin<S> {
         }
     }
 
-    fn is_unique(&self) -> bool {
-        false
+    fn name(&self) -> &str {
+        &self.plugin_name
     }
 }
 


### PR DESCRIPTION
Instead of marking the plugin as not unique, give it a unique name depending on the state it's loading in.

This means that
```rust
        // Add plugin for the splash screen
        .add_plugin(
            ProgressPlugin::new(AppState::Splash)
                .continue_to(AppState::MainMenu)
                .track_assets(),
        )
        // Add plugin for our game loading screen
        .add_plugin(ProgressPlugin::new(AppState::GameLoading).continue_to(AppState::InGame))
```
will work, but 

```rust
        // Add plugin for the splash screen
        .add_plugin(
            ProgressPlugin::new(AppState::Splash)
                .continue_to(AppState::MainMenu)
                .track_assets(),
        )
        // Add plugin for our game loading screen
        .add_plugin(ProgressPlugin::new(AppState::Splash).continue_to(AppState::InGame))
```
won't, blocking adding by mistake the plugin twice with the same state